### PR TITLE
package: update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function parse(url, fn) {
     var cat;
 
     $('#wiki-body h2, #wiki-body h2 + ul li').each(function(){
-      var name = this[0].name;
+      var name = this.name;
 
       // heading
       // TODO hierarchical

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "wiki"
   ],
   "dependencies": {
-    "cheerio": "0.12.3",
-    "superagent": "0.15.5"
+    "cheerio": "^0.2.2",
+    "superagent": "^3.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "wiki"
   ],
   "dependencies": {
-    "cheerio": "^0.2.2",
+    "cheerio": "0.20.0",
     "superagent": "^3.5.2"
   }
 }


### PR DESCRIPTION
I'm trying to deploy a lambda function which uses `wiki-registry`, but browserifying the function causes a super weird error from the version of `cheerio` used here.

This patch updates `cheerio` (and `superagent`, just for good measure) in attempt to resolve this issue.